### PR TITLE
Renumber clusters in markers file where necessary

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -547,9 +547,13 @@ process mark_marker_resolutions {
 
 // Convert the marker files to tsv
 
-process markers_to_tsv {
+process renumber_markers_to_tsv {
     
     publishDir "$resultsRoot/bundle", mode: 'move', overwrite: true
+
+    memory { 5.GB * task.attempt }
+    errorStrategy { task.exitStatus == 130 || task.exitStatus == 137 ? 'retry' : 'finish' }
+    maxRetries 20
     
     input:
         set val(resolution), file(markersFile) from MARKERS_BY_RESOLUTION

--- a/main.nf
+++ b/main.nf
@@ -558,7 +558,15 @@ process markers_to_tsv {
         set val(resolution), file("markers_*.tsv") into TSV_MARKERS
 
     """
-    cat $markersFile | sed 's/,/\t/g' > markers_${resolution}.tsv
+    #!/usr/bin/env Rscript
+
+    markers <- read.csv('${markersFile}', check.names = FALSE)
+
+    if (min(markers\$groups) == 0){
+        markers\$groups <- markers\$groups + 1
+    }
+
+    write.table(markers, file='markers_${resolution}.tsv', sep="\t", quote=FALSE, row.names=FALSE)
     """
 }
 


### PR DESCRIPTION
This PR hiacks a previously simple bundling process (replacing csvs with tsvs), using an R scriptlet to do renumber 0-indexed clusters where necessary.