### PR TITLE
Feature/refs to bundle

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -142,7 +142,7 @@ process reference_supplementary_lines {
 
     """
     ensembl_version=\$(echo $referenceGtf | cut -d '.' -f 3)
-    echo -e "Reference\tEnsembl\t\$ensembl_version\t$referenceFasta, $referenceGTF" > software_reference.tsv
+    echo -e "Reference\tEnsembl\t\$ensembl_version\t$referenceFasta, $referenceGtf" > software_reference.tsv
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -117,13 +117,13 @@ process publish_reference {
         file(referenceGtf) from REFERENCE_GTF
 
     output:
-        file("out/$referenceFasta")
-        file("out/$referenceGtf")
+        file("reference/$referenceFasta")
+        file("reference/$referenceGtf")
         
     """
-    mkdir -p out
-    cp -P $referenceFasta out
-    cp -P $referenceGtf out
+    mkdir -p reference
+    cp -P $referenceFasta reference
+    cp -P $referenceGtf reference
     """
 }
 
@@ -142,7 +142,8 @@ process reference_supplementary_lines {
 
     """
     ensembl_version=\$(echo $referenceGtf | cut -d '.' -f 3)
-    echo -e "Reference\tEnsembl\t\$ensembl_version\t$referenceFasta, $referenceGtf" > software_reference.tsv
+    echo "Analysis\tSoftware\tVersion\tCitation" > software_reference.tsv
+    echo -e "Reference\tEnsembl\t\$ensembl_version\t$referenceFasta, $referenceGtf" >> software_reference.tsv
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -38,8 +38,8 @@ if (isDroplet && isSmart){
 // See what other inputs are provided
 
 RAW_MATRIX = Channel.fromPath( "$resultsRoot/${params.rawMatrix}", checkIfExists: true)
-REFERENCE_FASTA = Channel.fromPath( "${params.referenceFasta}", checkIfExists: true )
-REFERENCE_GTF = Channel.fromPath( "${params.referenceGtf}", checkIfExists: true )
+REFERENCE_FASTA = Channel.fromPath( "${params.referenceFasta}", checkIfExists: true ).first()
+REFERENCE_GTF = Channel.fromPath( "${params.referenceGtf}", checkIfExists: true ).first()
 
 if ( tertiaryWorkflow == 'scanpy-workflow' || tertiaryWorkflow == 'scanpy-galaxy' ){
     expressionTypes = expressionTypes + [ 'raw_filtered', 'filtered_normalised' ]
@@ -91,7 +91,7 @@ RAW_TPM_MATRIX.into{
 
 // Make manifest lines for references
 
-process reference_lines {
+process reference_manifest_lines {
 
     input:
         file(referenceFasta) from REFERENCE_FASTA
@@ -103,6 +103,46 @@ process reference_lines {
     """
     echo -e "reference_transcriptome\t$referenceFasta\t"
     echo -e "reference_annotation\t$referenceGtf\t"
+    """
+}
+
+// Publish reference files to bundle
+
+process publish_reference {
+    
+    publishDir "$resultsRoot/bundle", mode: 'copy', overwrite: true
+    
+    input:
+        file(referenceFasta) from REFERENCE_FASTA
+        file(referenceGtf) from REFERENCE_GTF
+
+    output:
+        file("out/$referenceFasta")
+        file("out/$referenceGtf")
+        
+    """
+    mkdir -p out
+    cp -P $referenceFasta out
+    cp -P $referenceGtf out
+    """
+}
+
+// Reference lines for supplementary/ software table. Putting these data there
+// is a bit of a hack until we figure out better ways of flagging the reference
+// used
+
+process reference_supplementary_lines {
+
+    input:
+        file(referenceFasta) from REFERENCE_FASTA
+        file(referenceGtf) from REFERENCE_GTF
+
+    output:
+        file("software_reference.tsv") into REFERENCE_SOFTWARE 
+
+    """
+    ensembl_version=\$(echo $referenceGtf | cut -d '.' -f 3)
+    echo -e "Reference\tEnsembl\t$\$ensembl_version\t$referenceFasta, $referenceGTF" > software_reference.tsv
     """
 }
 
@@ -199,6 +239,7 @@ process make_base_software_report {
 
 MASTER_SOFTWARE
     .concat(BASE_SOFTWARE)
+    .concat(REFERENCE_SOFTWARE)
     .collectFile(name: 'software.tsv', newLine: true, keepHeader: true )
     .set { ALL_BASE_SOFTWARE }
 

--- a/main.nf
+++ b/main.nf
@@ -142,7 +142,7 @@ process reference_supplementary_lines {
 
     """
     ensembl_version=\$(echo $referenceGtf | cut -d '.' -f 3)
-    echo -e "Reference\tEnsembl\t$\$ensembl_version\t$referenceFasta, $referenceGTF" > software_reference.tsv
+    echo -e "Reference\tEnsembl\t\$ensembl_version\t$referenceFasta, $referenceGTF" > software_reference.tsv
     """
 }
 


### PR DESCRIPTION
Currently it's a little difficult for users to identify which Ensembl reference has been used. There's no easy place to put this in the UI, but this does applies the following minimal fixes:

 * Reference files placed in analysis bundle under reference/. These could be loaded into e.g. FTP directory.
 * A 'reference' line added to the software file eventually displayed under https://www.ebi.ac.uk/gxa/sc/experiments/E-MTAB-6077/supplementary-information

This is somewhat linked to https://github.com/ebi-gene-expression-group/scxa-control-workflow/pull/8. The previous mimimal mechanism was to point users at the versions stated in the configuration files of the SC analysis repo. If we're to us centralised reference files instead that mechanism won't be viable, so we need to be more explicit on the UI.


