### PR TITLE
Rearrange logic for consistency between cluster and meta markers

### DIFF
--- a/bin/makeMarkerStats.R
+++ b/bin/makeMarkerStats.R
@@ -164,7 +164,7 @@ all_marker_files <- unlist(lapply(c('cluster', 'meta'), function(markerType){
     }
 }))
 
-if (length(all_markers_files) == 0){
+if (length(all_marker_files) == 0){
     write('Found no valid marker files', stderr())
     q(status = 1) 
 }

--- a/bin/makeMarkerStats.R
+++ b/bin/makeMarkerStats.R
@@ -32,25 +32,25 @@ option_list = list(
     help = "A pattern used to match marker files as downloaded from a Scanpy workflow with scanpy-scripts"
   ),
   make_option(
+    c("-y", "--meta-markers-dir"),
+    action = "store",
+    default = NA,
+    type = 'character',
+    help = "Directory path in which to find metadata marker files as downloaded from a Scanpy workflow with scanpy-scripts"
+  ),
+  make_option(
+    c("-m", "--meta-markers-file-pattern"),
+    action = "store",
+    default = "markers_*.tsv",
+    type = 'character',
+    help = "A pattern used to match marker files as downloaded from a Scanpy workflow with scanpy-scripts"
+  ),
+  make_option(
     c("-g", "--cellgroups-file"),
     action = "store",
     default = NA,
     type = 'character',
     help = "A tabular file in which additional cell groups column can be found"
-  ),
-  make_option(
-    c("-f", "--celltype-fields"),
-    action = "store",
-    default = 'inferred_cell_type',
-    type = 'character',
-    help = "Field name(s) (comma separated if multiple) in the cell type file from which cell type groupings can be derived"
-  ),
-  make_option(
-    c("-y", "--celltype-markers-files"),
-    action = "store",
-    default = NA,
-    type = 'character',
-    help = "File(s) (comma separated if multiple, in same order as celltype-fields) containing cell type marker statistics, to be included with the processing of the cluster markers"
   ),
   make_option(
     c("-s", "--select-top"),
@@ -93,22 +93,6 @@ ks <- clusters$K
 clusters <- t(clusters[,c(-1,-2)])
 colnames(clusters) <- as.character(ks)
 
-# Add other cell groupings, where provided
-
-if ((! is.na(opt$celltype_markers_files)) && (! is.na(opt$cellgroups_file)) && (! is.na(opt$celltype_fields))){
-  opt$celltype_fields <- unlist(strsplit(opt$celltype_fields, ','))
-
-  cellgroups <- fread(opt$cellgroups_file, select = c('id', opt$celltype_fields))
-  colnames(cellgroups) <- gsub('_', ' ', colnames(cellgroups))
-  for (cg in names(cellgroups)[-1]){
-    cellgroups[[cg]] <- sub('^$', 'None', cellgroups[[cg]])
-  }
-  
-  clusters <- merge(clusters, cellgroups, by.x = 'row.names', by.y = 'id', all.x = TRUE, sort = FALSE)
-  rownames(clusters) <- clusters$Row.names
-  clusters <- clusters[,-1]
-}
-
 # Read the count-based expression values
 
 # (first check if we need to gunzip)
@@ -136,24 +120,44 @@ colnames(counts) <- colData(counts)$Barcode
 # Now read in the markers
 
 print("Loading markers...")
-cluster_marker_files <- list.files(path = opt$cluster_markers_dir, pattern = basename(opt$cluster_markers_file_pattern), full.names = TRUE)
+marker_files <- unlist(lapply(c('cluster', 'meta'), function(markerType){
+    
+    if (! is.na(opt[[paste0(markerType, '_markers_dir')]])){
+        marker_files <- list.files(path = paste0(markerType, '_markers_dir'), pattern = basename(paste0(markerType, '_markers_file_pattern')), full.names = TRUE)
+        marker_cell_groupings <- sub('markers_(.+).tsv', '\\1', basename(marker_files))
 
-# Order cluster markers by k 
+        # Load metadata groupings and subset to those relevant in markers 
+        
+        if (markerType == 'meta'){
+            if ((! is.na(opt$cellgroups_file))){
+              cellgroups <- fread(opt$cellgroups_file)
+              colnames(cellgroups) <- gsub('_', ' ', colnames(cellgroups))
+              for (cg in names(cellgroups)[-1]){
+                cellgroups[[cg]] <- sub('^$', 'None', cellgroups[[cg]])
+              }
+              cellgroups <- cellgroups[, c('id', colnames(cellgroups) %in% marker_cell_groupings), drop = FALSE]
+              clusters <- merge(clusters, cellgroups, by.x = 'row.names', by.y = 'id', all.x = TRUE, sort = FALSE)
+              rownames(clusters) <- clusters$Row.names
+              clusters <- clusters[,-1]
+            }
+        }
 
-k_vals <- sub('markers_([0-9]+).tsv', '\\1', basename(cluster_marker_files))
-marker_files <- structure(cluster_marker_files[order(as.numeric(k_vals))], names = sort(as.numeric(k_vals)))
+        missing <- marker_cell_groupings[! marker_cell_groupings %in% colnames(clusters)]
+        if (length(missing) > 0){
+            write(paste('Marker file for', paste(missing, collapse=', '), 'missing its cell groups/ clusters'), stderr())
+            q(status = 1)
+        }
 
-# Add in cell markers where provided
+        marker_files <- structure(marker_files, names = marker_cell_groupings)
+        if (markerType == 'cluster'){
+            marker_files <- marker_files[order(as.numeric(names(marker_files)))]
+        }
+        marker_files
+    }else{
+        NULL
+    }
 
-if (! is.na(opt$celltype_markers_files)){
-  print("Cell type markers present...")
-  celltype_markers_files <- unlist(strsplit(opt$celltype_markers_files, ','))
-  if ( length(celltype_markers_files) != length(opt$celltype_fields)){
-    write(paste0("Number of markers files supplied (", length(celltype_markers_files), ') does not match number of cell type fields supplied (', length(opt$celltype_fields), ')'), stderr())
-    q(status = 1) 
-  } 
-  marker_files <- c(marker_files, structure(celltype_markers_files, names = gsub('_', ' ', opt$celltype_fields)))
-}
+}))
 
 cluster_markers <- do.call(rbind, lapply(names(marker_files), function(x) cbind(variable = x, fread(marker_files[x], select = c('cluster', 'genes', 'pvals_adj'), colClasses = c('character', 'character', 'integer', 'character', 'numeric', 'numeric', 'numeric', 'numeric')))))
 cluster_markers$cluster <- sub('^nan$', 'None', cluster_markers$cluster)

--- a/bin/makeMarkerStats.R
+++ b/bin/makeMarkerStats.R
@@ -169,7 +169,7 @@ if (length(all_markers_files) == 0){
     q(status = 1) 
 }
 
-cluster_markers <- do.call(rbind, lapply(names(marker_files), function(x) cbind(variable = x, fread(marker_files[x], select = c('cluster', 'genes', 'pvals_adj'), colClasses = c('character', 'character', 'integer', 'character', 'numeric', 'numeric', 'numeric', 'numeric')))))
+cluster_markers <- do.call(rbind, lapply(names(all_marker_files), function(x) cbind(variable = x, fread(all_marker_files[x], select = c('cluster', 'genes', 'pvals_adj'), colClasses = c('character', 'character', 'integer', 'character', 'numeric', 'numeric', 'numeric', 'numeric')))))
 cluster_markers$cluster <- sub('^nan$', 'None', cluster_markers$cluster)
 
 # Rank by padj within each clustering (and filter)

--- a/main.nf
+++ b/main.nf
@@ -655,8 +655,8 @@ process mark_marker_param {
             cp -P $markersFile cluster_markers.tsv
         else
             cp -P $markersFile meta_markers.tsv
-            
         fi
+        echo -n $cellgroup_name
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -53,8 +53,7 @@ if ( tertiaryWorkflow == 'scanpy-workflow' || tertiaryWorkflow == 'scanpy-galaxy
     SCANPY_CLUSTERS = Channel.fromPath( "$resultsRoot/${params.clusters}", checkIfExists: true)
     SCANPY_TSNE = Channel.fromPath( "$resultsRoot/${params.tsneDir}/tsne_perplexity*.tsv", checkIfExists: true )
     SCANPY_UMAP = Channel.fromPath( "$resultsRoot/${params.umapDir}/umap_n_neighbors*.tsv", checkIfExists: true )
-    SCANPY_CLUSTER_MARKERS = Channel.fromPath( "$resultsRoot/${params.markersDir}/markers_*.tsv" )
-    SCANPY_META_MARKERS = Channel.fromPath( "$resultsRoot/${params.markersDir}/*_markers.tsv" )
+    SCANPY_MARKERS = Channel.fromPath( "$resultsRoot/${params.markersDir}/markers_*.tsv" )
 }else{
     RAW_FILTERED_MATRIX = Channel.empty()
     NORMALISED_MATRIX = Channel.empty()
@@ -638,37 +637,26 @@ FINAL_CLUSTERS.into{
 
 // Find out what resolutions are represented by the marker files
 
-process mark_marker_resolutions {
+process mark_marker_param {
 
     executor 'local'
     
     input:
-        file markersFile from SCANPY_CLUSTER_MARKERS
+        file markersFile from SCANPY_MARKERS
 
     output:
-        set stdout, file (markersFile) into CLUSTER_MARKERS_BY_RESOLUTION 
+        set stdout, file ('cluster_markers.tsv') optional true into CLUSTER_MARKERS_BY_RESOLUTION 
+        set val('meta_markers'), stdout, file ('meta_markers.tsv') optional true into META_MARKERS_BY_VAR 
 
     """
-        echo $markersFile | grep -o -E '[0-9]+' | tr -d \'\\n\' 
-    """
-}
-
-// Find out what resolutions are represented by the marker files
-
-process mark_marker_meta {
-
-    executor 'local'
-    
-    publishDir "$resultsRoot/bundle", mode: 'copy', overwrite: true
-    
-    input:
-        file markersFile from SCANPY_META_MARKERS
-
-    output:
-        set val('meta_markers'), stdout, file (markersFile) into META_MARKERS_BY_VAR 
-
-    """
-        echo "$markersFile" | rev | cut -d"_" -f2-  | rev | tr -d \'\\n\' 
+        cellgroup_name=\$(echo $markersFile | sed 's/markers_//g' | sed 's/.tsv//g')
+        echo "\$cellgroup_name" | grep -o -E '[0-9]+' > /dev/null
+        if [ \$? -eq 0 ]; then
+            cp -P $markersFile cluster_markers.tsv
+        else
+            cp -P $markersFile meta_markers.tsv
+            
+        fi
     """
 }
 
@@ -676,8 +664,6 @@ process mark_marker_meta {
 
 process renumber_markers {
     
-    publishDir "$resultsRoot/bundle", mode: 'copy', overwrite: true
-
     memory { 5.GB * task.attempt }
     errorStrategy { task.exitStatus == 130 || task.exitStatus == 137 ? 'retry' : 'finish' }
     maxRetries 20
@@ -703,9 +689,25 @@ process renumber_markers {
     """
 }
 
-// Combine the listing of markers files for the manifest
+// Publish and combine the listing of markers files for the manifest
 
-RENUMBERED_CLUSTER_MARKERS_BY_RESOLUTION.concat(META_MARKERS_BY_VAR).into{
+process publish_markers {
+    
+    publishDir "$resultsRoot/bundle", mode: 'copy', overwrite: true
+    executor 'local'
+
+    input:
+        set val(markerType), val(param), file ('markers.tsv') from RENUMBERED_CLUSTER_MARKERS_BY_RESOLUTION.concat(META_MARKERS_BY_VAR)
+    
+    output:
+        set val(markerType), val(param), file("markers_${param}.tsv") into ALL_MARKERS
+
+    """
+    cp -P markers.tsv "markers_${param}.tsv"
+    """
+}
+
+ALL_MARKERS.into{
     ALL_MARKERS_FOR_MANIFEST
     ALL_MARKERS_FOR_SUMMARY
 }


### PR DESCRIPTION
This is a PR associated with https://github.com/ebi-gene-expression-group/scxa-workflows/pull/21, to bundle marker genes for metadata variable in a manner more consistent with that of clustering, since those markers are now generated by the same collection process in Galaxy, and named in the same way. 

Tested and works on experiments with and without metadata (i.e. cell type) markers. 