### PR TITLE
Prevent incomplete cell_to_lib

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -503,7 +503,7 @@ process cell_library_mappings {
             
             nlines=\$(cat \${cellToLib}.tmp | wc -l)
             if [ "\$nlines" -lt 2 ]; then   
-                echo "\${cellToLib}.tmp file creation failed"; 
+                echo "\${cellToLib}.tmp file creation failed" 
                 exit 1
             else
                 mv \${cellToLib}.tmp \${cellToLib}

--- a/main.nf
+++ b/main.nf
@@ -501,9 +501,9 @@ process cell_library_mappings {
                 echo -e "\$b\t\$run" 
             done >> \${cellToLib}.tmp
             
-            nlines=$(cat \${cellToLib}.tmp | wc -l)
-            if [ "$nlines" -lt 2 ]; then   
-                echo "Cell_to_library file creation failed"; 
+            nlines=\$(cat \${cellToLib}.tmp | wc -l)
+            if [ "\$nlines" -lt 2 ]; then   
+                echo "\${cellToLib}.tmp file creation failed"; 
             else
                 mv \${cellToLib}.tmp \${cellToLib}
             fi

--- a/main.nf
+++ b/main.nf
@@ -492,13 +492,14 @@ process cell_library_mappings {
 
     """
         if [ "$isDroplet" = 'true' ]; then
-            echo "# $sampleField" > cell_to_library.txt
+            echo "# $sampleField" > cell_to_library.txt.tmp
 
             zcat $barcodesFile | while read -r b; do 
                 barcode=\${b##*-} 
                 run=\${b/-\$barcode/''}
                 echo -e "\$b\t\$run" 
-            done >> cell_to_library.txt
+            done >> cell_to_library.txt.tmp
+            mv cell_to_library.txt.tmp cell_to_library.txt
         fi
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -492,14 +492,21 @@ process cell_library_mappings {
 
     """
         if [ "$isDroplet" = 'true' ]; then
-            echo "# $sampleField" > cell_to_library.txt.tmp
+            cellToLib=cell_to_library.txt
+            echo "# $sampleField" > \${cellToLib}.tmp
 
             zcat $barcodesFile | while read -r b; do 
                 barcode=\${b##*-} 
                 run=\${b/-\$barcode/''}
                 echo -e "\$b\t\$run" 
-            done >> cell_to_library.txt.tmp
-            mv cell_to_library.txt.tmp cell_to_library.txt
+            done >> \${cellToLib}.tmp
+            
+            nlines=$(cat \${cellToLib}.tmp | wc -l)
+            if [ "$nlines" -lt 2 ]; then   
+                echo "Cell_to_library file creation failed"; 
+            else
+                mv \${cellToLib}.tmp \${cellToLib}
+            fi
         fi
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -504,6 +504,7 @@ process cell_library_mappings {
             nlines=\$(cat \${cellToLib}.tmp | wc -l)
             if [ "\$nlines" -lt 2 ]; then   
                 echo "\${cellToLib}.tmp file creation failed"; 
+                exit 1
             else
                 mv \${cellToLib}.tmp \${cellToLib}
             fi


### PR DESCRIPTION
This PR makes doubly sure that creation cell_to_libary.txt files are only marked as complete when the body of the file is written. 

I'm seeing cases where only the header line is present. If this is because the process was disrupted before the rest of the file was written, then writing to a temp file until complete should fix the problem. Nextflow's mechanisms shouldn't have marked the process as successful in that case, so I'm not 100% confident in this. 

I've a nasty feeling it might be due to a file system issue in reading the file (for example lost mounts on the cluster nodes). Checking the number of lines should mitigate that.